### PR TITLE
Return a collection of frames from StackFrame>>stackOfSize:

### DIFF
--- a/Portishead/Portishead-Core.pax
+++ b/Portishead/Portishead-Core.pax
@@ -862,9 +862,8 @@ minVal
 
 !StackFrame methodsFor!
 
-stackOfSize: anInteger
-
-	^(self stackTrace: anInteger) subStrings: Character cr! !
+stackOfSize: limit
+	^self getFrames: limit.! !
 !StackFrame categoriesFor: #stackOfSize:!printing!private! !
 
 !String methodsFor!


### PR DESCRIPTION
Pharo implementation returns a collection of Contexts, definitely not just a string. We can just redirect to existing #getFrames:.